### PR TITLE
Fix GitHub Pages link formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Gloomy Companion inspired React app for managing monster health and status effects in the table top game Gloomhaven
 
 ## GitHub Pages Link
-(Gloomy-monsters)[https://ntpotraz.github.io/gloomy-monsters/]
+[Gloomy Monsters](https://ntpotraz.github.io/gloomy-monsters/)
 
 ## Purpose
 Months into our campaign, my friends and I realized how cumbersome it was for the person keeping track of the monster health and status effects. Swapping out the damage tokens for dice helped a bit, but the monster cards still got really full and a nightmare to deal with, especially with certain classes that can quickly apply debuffs to numerous monsters. Gloomy Monsters aims to declutter the table and speed up the setup so that you can get back into the action! No more sifting through stacks of monster cards to find that last scenario monster, or stacking tokens upon tokens when having to use the 10 monster sleeve. Gloomy Monster takes up the size of a laptop or tablet on the table, and instantly searches and adds monsters to the scenario, containing all the stats and characteristics you need to know for each monster.


### PR DESCRIPTION
Corrected the link formatting for the GitHub Pages link.